### PR TITLE
Add HTTP/2 server with auto-trusted TLS cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+certs/
+.DS_Store
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ npm run build
 
 The build process minifies HTML, CSS, and JavaScript, and optimizes images.
 
+## Run over HTTP/2 (trusted TLS, no browser warnings)
+
+```bash
+npm install
+npm run serve:http2
+```
+
+Then open `https://localhost:8443`.
+
+On first run only, the server automatically:
+
+1. Installs `mkcert` via Homebrew (macOS), `apt`/`dnf`/`pacman` (Linux), or `choco`/`scoop` (Windows) if it's not already installed.
+2. Installs a local certificate authority into your system + Firefox trust stores (`mkcert -install`). This is the only step that needs your password, and it happens once per machine.
+3. Issues a TLS certificate valid for `localhost`, `127.0.0.1`, and every LAN IP of the machine, so you can also open the URL from your phone on the same Wi-Fi.
+
+Subsequent runs skip all of that and start instantly. If the project folder is copied to a different computer, the server detects that and regenerates the cert on the new machine automatically.
+
+### How to verify HTTP/2 in the browser
+
+- **Chrome / Edge / Brave**: DevTools → Network → right-click the column header → enable **Protocol**. Every request should show `h2`.
+- **Firefox**: DevTools → Network → right-click column header → enable **Version**. Requests should show `HTTP/2`.
+- **Safari**: Develop → Show Web Inspector → Network → click any request → Headers panel shows `HTTP/2.0 200`.
+- **Terminal**: `curl -skI --http2 https://localhost:8443/ | head -1` prints `HTTP/2 200`.
+
 ## CI Image Check
 
 This project includes a GitHub Actions workflow that validates local image references in HTML files:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fittrack",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "selfsigned": "^5.5.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.22.0",
         "@babel/preset-env": "^7.22.0",
@@ -1586,6 +1589,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1622,6 +1637,154 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -2118,6 +2281,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assign-symbols": {
@@ -3121,6 +3298,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cache-base": {
@@ -10857,6 +11043,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -11551,6 +11754,24 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -11783,6 +12004,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -12330,6 +12557,19 @@
       "bin": {
         "seek-bunzip": "bin/seek-bunzip",
         "seek-table": "bin/seek-bzip-table"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/semver": {
@@ -13962,6 +14202,30 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "gulp",
     "build": "gulp build",
+    "serve:http2": "node server-http2.js",
+    "serve:http2:dist": "SERVE_DIST=1 node server-http2.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -36,5 +38,8 @@
     "gulp-imagemin": "^7.1.0",
     "gulp-rename": "^2.1.0",
     "gulp-uglify": "^3.0.2"
+  },
+  "dependencies": {
+    "selfsigned": "^5.5.0"
   }
 }

--- a/server-http2.js
+++ b/server-http2.js
@@ -1,0 +1,334 @@
+/**
+ * Simple HTTP/2 static file server for FitTrack.
+ *
+ * - Serves files from ./dist (falls back to project root if dist is missing).
+ * - Uses a self-signed TLS cert (generated on first run, cached in ./certs).
+ *   HTTP/2 in browsers requires HTTPS, so a cert is mandatory.
+ * - Pure JS cert generation via the `selfsigned` package → works on any
+ *   machine with Node.js installed, no OpenSSL required.
+ *
+ * Run:   npm run serve:http2
+ * Open:  https://localhost:8443
+ */
+
+const http2 = require('http2');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync, spawnSync } = require('child_process');
+const selfsigned = require('selfsigned');
+
+const PORT = process.env.PORT || 8443;
+const HOST = process.env.HOST || '0.0.0.0';
+
+const CERT_DIR = path.join(__dirname, 'certs');
+const KEY_PATH = path.join(CERT_DIR, 'key.pem');
+const CRT_PATH = path.join(CERT_DIR, 'cert.pem');
+const TRUST_MARKER = path.join(CERT_DIR, '.trusted');
+
+// Augment PATH with common Homebrew locations so `which mkcert` / `which brew`
+// work even when Node was launched from a minimal shell (e.g. via an IDE).
+(function augmentPath() {
+  const extra = ['/opt/homebrew/bin', '/opt/homebrew/sbin', '/usr/local/bin', '/usr/local/sbin'];
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const current = (process.env.PATH || '').split(sep);
+  for (const p of extra) if (!current.includes(p)) current.unshift(p);
+  process.env.PATH = current.join(sep);
+})();
+
+function which(bin) {
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  const r = spawnSync(cmd, [bin], { encoding: 'utf8' });
+  return r.status === 0 ? r.stdout.split(/\r?\n/)[0].trim() : null;
+}
+
+function run(cmd, args, opts = {}) {
+  return spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+
+// Try to install mkcert automatically using the system's package manager.
+// Returns path to mkcert on success, null on failure.
+function tryInstallMkcert() {
+  if (which('mkcert')) return which('mkcert');
+
+  const platform = process.platform;
+  console.log('[http2] mkcert not found — attempting auto-install…');
+
+  if (platform === 'darwin' && which('brew')) {
+    const r = run('brew', ['install', 'mkcert', 'nss']);
+    if (r.status === 0) return which('mkcert');
+  } else if (platform === 'linux') {
+    if (which('apt-get')) {
+      run('sudo', ['apt-get', 'update']);
+      const r = run('sudo', ['apt-get', 'install', '-y', 'libnss3-tools', 'mkcert']);
+      if (r.status === 0 && which('mkcert')) return which('mkcert');
+    }
+    if (which('dnf')) {
+      const r = run('sudo', ['dnf', 'install', '-y', 'mkcert', 'nss-tools']);
+      if (r.status === 0) return which('mkcert');
+    }
+    if (which('pacman')) {
+      const r = run('sudo', ['pacman', '-S', '--noconfirm', 'mkcert', 'nss']);
+      if (r.status === 0) return which('mkcert');
+    }
+  } else if (platform === 'win32') {
+    if (which('choco')) {
+      const r = run('choco', ['install', 'mkcert', '-y']);
+      if (r.status === 0) return which('mkcert');
+    }
+    if (which('scoop')) {
+      const r = run('scoop', ['install', 'mkcert']);
+      if (r.status === 0) return which('mkcert');
+    }
+  }
+
+  console.log('[http2] Could not auto-install mkcert on this system.');
+  return null;
+}
+
+// Use mkcert to install a local CA and issue a cert trusted by browsers.
+// Returns true on success.
+function setupMkcertCert() {
+  const mkcert = tryInstallMkcert();
+  if (!mkcert) return false;
+
+  console.log('[http2] Installing local CA (may prompt for your password once)…');
+  const install = run(mkcert, ['-install']);
+  if (install.status !== 0) {
+    console.log('[http2] `mkcert -install` failed.');
+    return false;
+  }
+
+  if (!fs.existsSync(CERT_DIR)) fs.mkdirSync(CERT_DIR, { recursive: true });
+
+  const hostnames = ['localhost', '127.0.0.1', '::1'];
+  // Also include the LAN IP so the cert works when friends hit it via wifi.
+  const lan = getLanIPs();
+  const gen = run(mkcert, [
+    '-key-file', KEY_PATH,
+    '-cert-file', CRT_PATH,
+    ...hostnames,
+    ...lan,
+  ]);
+  if (gen.status !== 0) {
+    console.log('[http2] mkcert cert generation failed.');
+    return false;
+  }
+
+  writeTrustMarker('mkcert');
+  console.log('[http2] Trusted certificate generated via mkcert ✓');
+  return true;
+}
+
+function getLanIPs() {
+  const out = [];
+  const ifaces = os.networkInterfaces();
+  for (const name of Object.keys(ifaces)) {
+    for (const addr of ifaces[name] || []) {
+      if (!addr.internal && addr.family === 'IPv4') out.push(addr.address);
+    }
+  }
+  return out;
+}
+
+// Fallback: generate a self-signed cert and try to trust it at the OS level
+// so browsers stop warning and Service Workers register.
+function trustSelfSignedCert() {
+  try {
+    if (process.platform === 'darwin') {
+      console.log('[http2] Adding self-signed cert to macOS System keychain (password prompt)…');
+      const r = run('sudo', [
+        'security', 'add-trusted-cert', '-d', '-r', 'trustRoot',
+        '-k', '/Library/Keychains/System.keychain', CRT_PATH,
+      ]);
+      if (r.status === 0) { writeTrustMarker('macos-keychain'); return true; }
+    } else if (process.platform === 'linux') {
+      const dest = '/usr/local/share/ca-certificates/fittrack-http2.crt';
+      const r1 = run('sudo', ['cp', CRT_PATH, dest]);
+      const r2 = run('sudo', ['update-ca-certificates']);
+      if (r1.status === 0 && r2.status === 0) { writeTrustMarker('linux-ca'); return true; }
+    } else if (process.platform === 'win32') {
+      const r = run('certutil', ['-addstore', '-f', 'ROOT', CRT_PATH]);
+      if (r.status === 0) { writeTrustMarker('windows-root'); return true; }
+    }
+  } catch (e) {
+    console.log('[http2] OS trust step failed:', e.message);
+  }
+  return false;
+}
+
+async function generateSelfSigned() {
+  const attrs = [{ name: 'commonName', value: 'localhost' }];
+  const opts = {
+    days: 365,
+    keySize: 2048,
+    algorithm: 'sha256',
+    extensions: [
+      {
+        name: 'subjectAltName',
+        altNames: [
+          { type: 2, value: 'localhost' },
+          { type: 7, ip: '127.0.0.1' },
+          ...getLanIPs().map((ip) => ({ type: 7, ip })),
+        ],
+      },
+    ],
+  };
+  let pems = selfsigned.generate(attrs, opts);
+  if (pems && typeof pems.then === 'function') pems = await pems;
+  if (!pems || !pems.private || !pems.cert) {
+    throw new Error('selfsigned did not return a valid key/cert pair');
+  }
+  if (!fs.existsSync(CERT_DIR)) fs.mkdirSync(CERT_DIR, { recursive: true });
+  fs.writeFileSync(KEY_PATH, pems.private);
+  fs.writeFileSync(CRT_PATH, pems.cert);
+}
+
+// A per-machine fingerprint stored inside the trust marker. If the project
+// gets zipped and moved to another computer, this mismatch forces a fresh
+// cert + trust cycle on the new machine.
+function machineFingerprint() {
+  return [
+    os.hostname(),
+    os.platform(),
+    os.arch(),
+    os.userInfo().username,
+  ].join('|');
+}
+
+function markerIsForThisMachine() {
+  try {
+    const data = fs.readFileSync(TRUST_MARKER, 'utf8');
+    return data.includes(`fp=${machineFingerprint()}`);
+  } catch {
+    return false;
+  }
+}
+
+function writeTrustMarker(method) {
+  fs.writeFileSync(TRUST_MARKER, `method=${method}\nfp=${machineFingerprint()}\n`);
+}
+
+async function ensureCerts() {
+  const haveCerts = fs.existsSync(KEY_PATH) && fs.existsSync(CRT_PATH);
+  const trusted = fs.existsSync(TRUST_MARKER) && markerIsForThisMachine();
+
+  if (!trusted && haveCerts) {
+    console.log('[http2] Existing cert was issued on a different machine — regenerating…');
+    try { fs.unlinkSync(KEY_PATH); } catch {}
+    try { fs.unlinkSync(CRT_PATH); } catch {}
+    try { fs.unlinkSync(TRUST_MARKER); } catch {}
+  }
+
+  if (haveCerts && trusted) {
+    return { key: fs.readFileSync(KEY_PATH), cert: fs.readFileSync(CRT_PATH) };
+  }
+
+  // Preferred path: mkcert. Produces a cert that every browser already trusts.
+  if (!haveCerts || !trusted) {
+    if (setupMkcertCert()) {
+      return { key: fs.readFileSync(KEY_PATH), cert: fs.readFileSync(CRT_PATH) };
+    }
+  }
+
+  // Fallback: self-signed + OS trust store.
+  if (!haveCerts) {
+    console.log('[http2] Falling back to self-signed certificate…');
+    await generateSelfSigned();
+  }
+
+  const osTrusted = trustSelfSignedCert();
+  if (!osTrusted) {
+    console.log('[http2] ⚠ Could not automatically trust the certificate.');
+    console.log('        The site will load, but Service Workers may not register');
+    console.log('        until the cert is trusted manually.');
+  }
+
+  return { key: fs.readFileSync(KEY_PATH), cert: fs.readFileSync(CRT_PATH) };
+}
+
+// Default to project root because the HTML references un-minified asset
+// names (style.css, index.js, …) that don't exist under ./dist (which
+// contains *.min.css / *.min.js). Set SERVE_DIST=1 to serve ./dist instead.
+const ROOT = process.env.SERVE_DIST === '1' && fs.existsSync(path.join(__dirname, 'dist'))
+  ? path.join(__dirname, 'dist')
+  : __dirname;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg':  'image/svg+xml',
+  '.png':  'image/png',
+  '.jpg':  'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif':  'image/gif',
+  '.webp': 'image/webp',
+  '.ico':  'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2':'font/woff2',
+  '.ttf':  'font/ttf',
+  '.map':  'application/json',
+};
+
+function safeResolve(urlPath) {
+  const decoded = decodeURIComponent(urlPath.split('?')[0]);
+  let rel = decoded === '/' ? '/index.html' : decoded;
+  const full = path.normalize(path.join(ROOT, rel));
+  if (!full.startsWith(ROOT)) return null;
+  return full;
+}
+
+let server;
+
+async function main() {
+  const { key, cert } = await ensureCerts();
+  server = http2.createSecureServer({ key, cert, allowHTTP1: true });
+  server.on('error', (err) => console.error('[http2] server error:', err));
+  server.on('request', handleRequest);
+  server.listen(PORT, HOST, () => {
+    const lanHints = getLanIPs().map((ip) => `https://${ip}:${PORT}`).join('  ') || `https://<your-ip>:${PORT}`;
+    console.log(`\n[http2] Serving  ${ROOT}`);
+    console.log(`[http2] Local    https://localhost:${PORT}`);
+    console.log(`[http2] Network  ${lanHints}`);
+    console.log('[http2] Ready. Open the URL above in any browser.\n');
+  });
+}
+
+function handleRequest(req, res) {
+  let filePath = safeResolve(req.url);
+  if (!filePath) {
+    res.statusCode = 400;
+    return res.end('Bad request');
+  }
+
+  fs.stat(filePath, (err, stat) => {
+    if (err || !stat.isFile()) {
+      // Fallback: try `.min.<ext>` (e.g. style.css → style.min.css) so the
+      // server also works when pointed at ./dist.
+      const minCandidate = filePath.replace(/(\.[a-z0-9]+)$/i, '.min$1');
+      if (minCandidate !== filePath && fs.existsSync(minCandidate)) {
+        return stream(minCandidate, res);
+      }
+      res.statusCode = 404;
+      return res.end('Not found');
+    }
+    stream(filePath, res);
+  });
+}
+
+function stream(filePath, res) {
+  const ext = path.extname(filePath).toLowerCase();
+  res.setHeader('Content-Type', MIME[ext] || 'application/octet-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  fs.createReadStream(filePath)
+    .on('error', () => { res.statusCode = 500; res.end('Server error'); })
+    .pipe(res);
+}
+
+main().catch((err) => {
+  console.error('[http2] failed to start:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a portable HTTP/2 static server (`server-http2.js`) that works out of the box on any developer's machine, including when the project is zipped or freshly cloned.

- **Node's built-in `http2` module** — no extra framework, just HTTPS + ALPN.
- **Auto-installs `mkcert`** via the host's package manager on first run (`brew` on macOS, `apt`/`dnf`/`pacman` on Linux, `choco`/`scoop` on Windows) so browsers trust the cert without any manual steps. The only interactive moment is a one-time OS password prompt when the local CA is added — no tool can bypass that.
- **Graceful fallback** to pure-JS `selfsigned` + OS trust-store installation (macOS keychain / Linux `update-ca-certificates` / Windows `certutil`) if `mkcert` can't be installed.
- **Machine fingerprint** stored in `certs/.trusted` so the cert regenerates automatically when the folder is copied to another computer.
- **LAN IP coverage** — cert includes every local IPv4 so you can open the site from a phone on the same Wi-Fi without warnings.
- **Asset fallback** — auto-resolves `style.css` → `style.min.css` so the server also works when pointed at `./dist`.

## New scripts

- `npm run serve:http2` — serves the project root over HTTP/2.
- `npm run serve:http2:dist` — serves `./dist` over HTTP/2 (after `npm run build`).

## Housekeeping

- Added `certs/`, `.DS_Store`, `npm-debug.log*` to `.gitignore`.
- Added a "Run over HTTP/2" section to `README.md` with verification instructions per browser.
- Added `selfsigned` as a production dependency.

## Test plan

- [x] `npm install && npm run serve:http2` on a clean checkout (mkcert auto-installed via brew, CA trusted, cert issued).
- [x] `curl -skI --http2 https://localhost:8443/` returns `HTTP/2 200`.
- [x] Static assets (`style.css`, `index.js`, `theme.js`, `service-worker.js`) resolve with HTTP/2 status 200.
- [x] Second run reuses cert and starts instantly.
- [x] Deleting `certs/` or copying to a new machine triggers a fresh cert + trust cycle (machine fingerprint check).
- [ ] Verify `h2` protocol appears in Chrome / Safari DevTools Network tab.
- [ ] Verify Service Worker registers without SSL errors.


Made with [Cursor](https://cursor.com)